### PR TITLE
Fixed link for @stoodMag account.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4827,7 +4827,7 @@
 
 - [@Sargsian](https://github.com/Sargsian)
 
-- [@StoodMag] (https://github.com/StoodMag/)
+- [@StoodMag](https://github.com/StoodMag/)
 
 - [@LEO0331](https://github.com/LEO0331/)
 


### PR DESCRIPTION
There was a space between the link and the name.